### PR TITLE
addition to data layer references

### DIFF
--- a/documents/Google-Analytics/google-analytics-data-layer.md
+++ b/documents/Google-Analytics/google-analytics-data-layer.md
@@ -76,3 +76,4 @@ detail view를 보면
 [The Data Layer](http://www.simoahava.com/analytics/data-layer/)
 [Google Tag Manager’s Data Model](http://www.simoahava.com/analytics/google-tag-manager-data-model/)
 [Google Tag Manager for Web Tracking](https://developers.google.com/tag-manager/devguide)
+[Data Layer explained with Tutorial [2020]](https://bluerivermountains.com/en/data-layer)


### PR DESCRIPTION
Hey, I added a reference to a 2020 data layer guide that looks at both GTM and also Adobe Analytics to explain the underlying differences. I thought it would make a good addition to the list as being more up to date and tehrefore be helpful to your visitors :)

regards